### PR TITLE
Azure NAT Gateway POC

### DIFF
--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -244,6 +244,7 @@ resource "azurerm_subnet" "infrastructure_subnet" {
   resource_group_name       = "${azurerm_resource_group.pcf_resource_group.name}"
   virtual_network_name      = "${azurerm_virtual_network.pcf_virtual_network.name}"
   address_prefix            = "${var.pcf_infrastructure_subnet}"
+  network_security_group_id = "${azurerm_network_security_group.ops_manager_security_group.id}"
 }
 
 resource "azurerm_subnet_network_security_group_association" "ops_manager_security_group" {

--- a/modules/nat/gateway.tf
+++ b/modules/nat/gateway.tf
@@ -71,6 +71,21 @@ resource "azurerm_network_interface" "nat_instance_nic" {
   }
 }
 
+resource "azurerm_route_table" "nat_table" {
+  name                 = "${var.env_name}-nat-table"
+  location             = "${var.location}"
+  resource_group_name  = "${var.resource_group_name}"
+}
+
+resource "azurerm_route" "nat_rule1" {
+  name                   = "${var.env_name}-nat-rule1"
+  resource_group_name    = "${var.resource_group_name}"
+  route_table_name       = "${azurerm_route_table.nat_table.name}"
+  address_prefix         = "0.0.0.0/0"
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = "${azurerm_network_interface.nat_instance_nic.private_ip_address}"
+}
+
 # ==================== NAT Instance(s)
 
 resource "azurerm_virtual_machine" "nat_instance_vm" {
@@ -136,24 +151,28 @@ resource "azurerm_virtual_machine_extension" "nat_instance" {
 
 # ==================== Outputs
 
-output "nat_public_ip" {
+output "public_ip" {
   value = "${azurerm_public_ip.nat_public_ip.ip_address}"
 }
 
-output "nat_private_ip" {
+output "private_ip" {
   value = "${azurerm_network_interface.nat_instance_nic.private_ip_address}"
 }
 
-output "nat_ssh_public_key" {
+output "ssh_public_key" {
   sensitive = true
   value     = "${tls_private_key.nat_instance.public_key_openssh}"
 }
 
-output "nat_ssh_private_key" {
+output "ssh_private_key" {
   sensitive = true
   value     = "${tls_private_key.nat_instance.private_key_pem}"
 }
 
-output "nat_subnet_id" {
+output "subnet_id" {
   value = "${azurerm_subnet.nat_subnet.id}"
+}
+
+output "route_table_id" {
+  value = "${azurerm_route_table.nat_table.id}"
 }

--- a/modules/nat/gateway.tf
+++ b/modules/nat/gateway.tf
@@ -1,0 +1,159 @@
+# ==================== Variables
+
+variable "nat_subnet_cidr" {}
+variable "env_name" {}
+variable "resource_group_name" {}
+variable "network_name" {}
+variable "location" {}
+
+variable "nat_vm_size" {
+  default = "Standard_DS1_v2"
+}
+variable "nat_instance_count" {
+  default = 1
+}
+
+# ==================== Networking
+
+resource "azurerm_network_security_group" "nat_security_group" {
+  name                = "${var.env_name}-nat-security-group"
+  location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
+
+  security_rule {
+    name                       = "AllowAnyOutBoundInnerSubnet"
+    priority                   = 1000
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "VirtualNetwork"
+    destination_address_prefix = "Internet"
+  }
+}
+
+resource "azurerm_subnet" "nat_subnet" {
+  name = "${var.env_name}-nat-subnet"
+
+  resource_group_name       = "${var.resource_group_name}"
+  virtual_network_name      = "${var.network_name}"
+  address_prefix            = "${var.nat_subnet_cidr}"
+  network_security_group_id = "${azurerm_network_security_group.nat_security_group.id}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "nat_subnet" {
+  subnet_id                 = "${azurerm_subnet.nat_subnet.id}"
+  network_security_group_id = "${azurerm_network_security_group.nat_security_group.id}"
+}
+
+resource "azurerm_public_ip" "nat_public_ip" {
+  name                         = "nat-public-ip"
+  location                     = "${var.location}"
+  resource_group_name          = "${var.resource_group_name}"
+  public_ip_address_allocation = "static"
+  sku                          = "Standard"
+}
+
+resource "azurerm_network_interface" "nat_instance_nic" {
+  name                      = "${var.env_name}-nat-instance-nic"
+  depends_on                = ["azurerm_public_ip.nat_public_ip"]
+  location                  = "${var.location}"
+  resource_group_name       = "${var.resource_group_name}"
+  network_security_group_id = "${azurerm_network_security_group.nat_security_group.id}"
+
+  ip_configuration {
+    name                          = "${var.env_name}-nat-instance-ip-config"
+    subnet_id                     = "${azurerm_subnet.nat_subnet.id}"
+    private_ip_address_allocation = "static"
+    private_ip_address            = "${cidrhost(azurerm_subnet.nat_subnet.address_prefix, 5)}"
+    public_ip_address_id          = "${azurerm_public_ip.nat_public_ip.id}"
+  }
+}
+
+# ==================== NAT Instance(s)
+
+resource "azurerm_virtual_machine" "nat_instance_vm" {
+  name                          = "${var.env_name}-nat-instance-vm"
+  location                      = "${var.location}"
+  resource_group_name           = "${var.resource_group_name}"
+  network_interface_ids         = ["${azurerm_network_interface.nat_instance_nic.id}"]
+  vm_size                       = "${var.nat_vm_size}"
+  delete_os_disk_on_termination = "true"
+  #count                         = "${var.nat_instance_count}"
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04.0-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "nat-instance-disk.vhd"
+    caching           = "ReadWrite"
+    os_type           = "linux"
+    create_option     = "FromImage"
+    managed_disk_type = "Premium_LRS"
+  }
+
+  os_profile {
+    #computer_name  = "${var.env_name}-nat${count.index}"
+    computer_name  = "${var.env_name}-nat1"
+    admin_username = "ubuntu"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      path     = "/home/ubuntu/.ssh/authorized_keys"
+      key_data = "${tls_private_key.nat_instance.public_key_openssh}"
+    }
+  }
+}
+
+resource "tls_private_key" "nat_instance" {
+  algorithm = "RSA"
+  rsa_bits  = "4096"
+}
+
+resource "azurerm_virtual_machine_extension" "nat_instance" {
+  name                 = "${var.env_name}-nat-instance-vm-ext"
+  location             = "${var.location}"
+  resource_group_name  = "${var.resource_group_name}"
+  virtual_machine_name = "${azurerm_virtual_machine.nat_instance_vm.name}"
+  publisher            = "Microsoft.Azure.Extensions"
+  type                 = "CustomScript"
+  type_handler_version = "2.0"
+
+  settings = <<SETTINGS
+    {
+        "script": "cHY0LmlwX2ZvcndhcmQgPSAxCmNwIC9ldGMvc3lzY3RsLmNvbmYgL3RtcC9zeXNjdGwuY29uZgplY2hvICJuZXQuaXB2NC5pcF9mb3J3YXJkID0gMSIgPj4gL3RtcC9zeXNjdGwuY29uZgpzdWRvIGNwIC90bXAvc3lzY3RsLmNvbmYgL2V0Yy9zeXNjdGwuY29uZgoKIyBmaXJld2FsbGQKc3VkbyAvZXRjL2luaXQuZC9uZXR3b3JraW5nIHJlc3RhcnQKc3VkbyBhcHQtZ2V0IGluc3RhbGwgLXkgZmlyZXdhbGxkCnN1ZG8gc3lzdGVtY3RsIGVuYWJsZSBmaXJld2FsbGQKc3VkbyBzeXN0ZW1jdGwgc3RhcnQgZmlyZXdhbGxkCnN1ZG8gZmlyZXdhbGwtY21kIC0tc3RhdGUKc3VkbyBmaXJld2FsbC1jbWQgLS1zZXQtZGVmYXVsdC16b25lPWV4dGVybmFsCnN1ZG8gZmlyZXdhbGwtY21kIC0tcmVsb2FkCg=="
+    }
+    SETTINGS
+}
+
+# ==================== Outputs
+
+output "nat_public_ip" {
+  value = "${azurerm_public_ip.nat_public_ip.ip_address}"
+}
+
+output "nat_private_ip" {
+  value = "${azurerm_network_interface.nat_instance_nic.private_ip_address}"
+}
+
+output "nat_ssh_public_key" {
+  sensitive = true
+  value     = "${tls_private_key.nat_instance.public_key_openssh}"
+}
+
+output "nat_ssh_private_key" {
+  sensitive = true
+  value     = "${tls_private_key.nat_instance.private_key_pem}"
+}
+
+output "nat_subnet_id" {
+  value = "${azurerm_subnet.nat_subnet.id}"
+}

--- a/modules/ops_manager/ops_manager.tf
+++ b/modules/ops_manager/ops_manager.tf
@@ -68,6 +68,7 @@ resource "azurerm_storage_blob" "ops_manager_image" {
   storage_account_name   = "${azurerm_storage_account.ops_manager_storage_account.name}"
   storage_container_name = "${azurerm_storage_container.ops_manager_storage_container.name}"
   source_uri             = "${var.ops_manager_image_uri}"
+  type                   = "page"
 }
 
 resource "azurerm_image" "ops_manager_image" {

--- a/modules/pas/dns.tf
+++ b/modules/pas/dns.tf
@@ -3,7 +3,7 @@ resource "azurerm_dns_a_record" "apps" {
   zone_name           = "${var.dns_zone_name}"
   resource_group_name = "${var.resource_group_name}"
   ttl                 = "60"
-  records             = ["${azurerm_public_ip.web-lb-public-ip.ip_address}"]
+  records             = ["${azurerm_lb.web.private_ip_address}"]
 }
 
 resource "azurerm_dns_a_record" "sys" {
@@ -11,7 +11,7 @@ resource "azurerm_dns_a_record" "sys" {
   zone_name           = "${var.dns_zone_name}"
   resource_group_name = "${var.resource_group_name}"
   ttl                 = "60"
-  records             = ["${azurerm_public_ip.web-lb-public-ip.ip_address}"]
+  records             = ["${azurerm_lb.web.private_ip_address}"]
 }
 
 resource "azurerm_dns_a_record" "ssh" {

--- a/modules/pas/subnets.tf
+++ b/modules/pas/subnets.tf
@@ -7,6 +7,7 @@ resource "azurerm_subnet" "pas_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.pas_subnet_cidr}"
+  network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
 }
 
 resource "azurerm_subnet_network_security_group_association" "pas_subnet" {
@@ -21,6 +22,7 @@ resource "azurerm_subnet" "services_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.services_subnet_cidr}"
+  network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
 }
 
 resource "azurerm_subnet_network_security_group_association" "services_subnet" {

--- a/modules/pas/subnets.tf
+++ b/modules/pas/subnets.tf
@@ -7,7 +7,13 @@ resource "azurerm_subnet" "pas_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.pas_subnet_cidr}"
+  route_table_id            = "${var.nat_route_table_id}"
   network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
+}
+
+resource "azurerm_subnet_route_table_association" "pas_subnet" {
+  subnet_id      = "${azurerm_subnet.pas_subnet.id}"
+  route_table_id = "${var.nat_route_table_id}"
 }
 
 resource "azurerm_subnet_network_security_group_association" "pas_subnet" {
@@ -22,8 +28,15 @@ resource "azurerm_subnet" "services_subnet" {
   resource_group_name       = "${var.resource_group_name}"
   virtual_network_name      = "${var.network_name}"
   address_prefix            = "${var.services_subnet_cidr}"
+  route_table_id            = "${var.nat_route_table_id}"
   network_security_group_id = "${var.bosh_deployed_vms_security_group_id}"
 }
+
+resource "azurerm_subnet_route_table_association" "services_subnet" {
+  subnet_id      = "${azurerm_subnet.services_subnet.id}"
+  route_table_id = "${var.nat_route_table_id}"
+}
+
 
 resource "azurerm_subnet_network_security_group_association" "services_subnet" {
   subnet_id                 = "${azurerm_subnet.services_subnet.id}"

--- a/modules/pas/variables.tf
+++ b/modules/pas/variables.tf
@@ -14,4 +14,5 @@ variable "network_name" {}
 variable "pas_subnet_cidr" {}
 variable "services_subnet_cidr" {}
 
+variable "nat_route_table_id" {}
 variable "bosh_deployed_vms_security_group_id" {}

--- a/modules/pas/weblb.tf
+++ b/modules/pas/weblb.tf
@@ -1,11 +1,3 @@
-resource "azurerm_public_ip" "web-lb-public-ip" {
-  name                         = "web-lb-public-ip"
-  location                     = "${var.location}"
-  resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
-  sku                          = "Standard"
-  idle_timeout_in_minutes      = 30
-}
 
 resource "azurerm_lb" "web" {
   name                = "${var.env_name}-web-lb"
@@ -14,8 +6,10 @@ resource "azurerm_lb" "web" {
   sku                 = "Standard"
 
   frontend_ip_configuration = {
-    name                 = "frontendip"
-    public_ip_address_id = "${azurerm_public_ip.web-lb-public-ip.id}"
+    name                          = "frontendip"
+    subnet_id                     = "${azurerm_subnet.pas_subnet.id}"
+    private_ip_address            = "${cidrhost(azurerm_subnet.pas_subnet.address_prefix, 6)}"
+    private_ip_address_allocation = "Static"
   }
 }
 

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -72,6 +72,7 @@ module "pas" {
   dns_zone_name                       = "${module.infra.dns_zone_name}"
   network_name                        = "${module.infra.network_name}"
   bosh_deployed_vms_security_group_id = "${module.infra.bosh_deployed_vms_security_group_id}"
+  nat_route_table_id                  = "${module.nat.route_table_id}"
 }
 
 module "certs" {

--- a/terraforming-pas/main.tf
+++ b/terraforming-pas/main.tf
@@ -22,6 +22,16 @@ module "infra" {
   pcf_virtual_network_address_space = "${var.pcf_virtual_network_address_space}"
 }
 
+module "nat" {
+  source = "../modules/nat"
+
+  nat_subnet_cidr     = "${var.pcf_nat_subnet}"
+  env_name            = "${var.env_name}"
+  resource_group_name = "${module.infra.resource_group_name}"
+  network_name        = "${module.infra.network_name}"
+  location            = "${var.location}"
+}
+
 module "ops_manager" {
   source = "../modules/ops_manager"
 

--- a/terraforming-pas/outputs.tf
+++ b/terraforming-pas/outputs.tf
@@ -221,6 +221,32 @@ output "isolation_segment" {
   }
 }
 
+output "nat_public_ip" {
+  value = "${module.nat.public_ip}"
+}
+
+output "nat_private_ip" {
+  value = "${module.nat.private_ip}"
+}
+
+output "nat_ssh_public_key" {
+  sensitive = true
+  value     = "${module.nat.ssh_public_key}"
+}
+
+output "nat_ssh_private_key" {
+  sensitive = true
+  value     = "${module.nat.ssh_private_key}"
+}
+
+output "nat_subnet_id" {
+  value = "${module.nat.subnet_id}"
+}
+
+output "nat_route_table_id" {
+  value = "${module.nat.route_table_id}"
+}
+
 # Deprecated properties
 
 output "management_subnet_name" {

--- a/terraforming-pas/variables.tf
+++ b/terraforming-pas/variables.tf
@@ -149,3 +149,8 @@ variable "pcf_services_subnet" {
   type    = "string"
   default = "10.0.4.0/22"
 }
+
+variable "pcf_nat_subnet" {
+  type    = "string"
+  default = "10.0.8.64/28"
+}


### PR DESCRIPTION
This creates a NAT gateway instance for outbound internet traffic similar to our GCP reference architecture. This setup has one static public IP address for all egress traffic which is typically [preferable for compliance and control](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/best-practices-network-security.md#perimeter-network-requirements).

- Use standard Azure ILBs (internal LBs)
- Create NAT "perimeter" subnet, instance, and security rules
- Configure pas and services subnets with user defined routes to NAT instance

This architecture would require monitoring of the NAT instance to ensure up time since it cannot be HA. The best you could do is create a hot spare and then manually change the route to the other instance should it fail. Lack of HA also has NAT instance upgrade implications. Ideally Microsoft should provide a HA managed NAT service in Azure.

This does _not_ currently apply the NAT rules to the infrastructure subnet.